### PR TITLE
Cut text values by length

### DIFF
--- a/force-app/main/default/classes/TestDataFactory.cls
+++ b/force-app/main/default/classes/TestDataFactory.cls
@@ -945,6 +945,23 @@ public class TestDataFactory {
         }
 
         /**
+        * @description cut String value to its length
+        * @param fieldDesc (Schema.DescribeFieldResult): field describe information
+        * @param textValue (String): String field value
+        * @return String field value with its length 
+        */
+        @TestVisible
+        private String getSubstringByLength(Schema.DescribeFieldResult fieldDesc, String textValue){
+            if (fieldDesc == null || textValue == null) {
+                return textValue;
+            }
+            if (textValue?.length() > fieldDesc?.getLength()) {
+                textValue = textValue.substring(0, fieldDesc?.getLength());
+            }
+            return textValue;
+        }
+
+        /**
         * @description test if a field requires a default value
         * @param fieldDesc (Schema.DescribeFieldResult): field describe information
         * @return true if a default value is required
@@ -1191,7 +1208,8 @@ public class TestDataFactory {
         * @return text default value
         */
         public virtual String getTextDefaultValue(Schema.DescribeSObjectResult sObjectDesc, Schema.DescribeFieldResult fieldDesc, Integer recordIndex){
-            return 'test'+recordIndex.format();
+            String textValue = 'test' + recordIndex.format();
+            return getSubstringByLength(fieldDesc, textValue);
         }
         /**
         * @description get the default value for TextArea field type

--- a/force-app/main/default/classes/TestDataFactory.cls
+++ b/force-app/main/default/classes/TestDataFactory.cls
@@ -956,7 +956,7 @@ public class TestDataFactory {
                 return textValue;
             }
             if (textValue?.length() > fieldDesc?.getLength()) {
-                textValue = textValue.substring(0, fieldDesc?.getLength());
+                textValue = textValue.substring(textValue.length() - fieldDesc?.getLength());
             }
             return textValue;
         }


### PR DESCRIPTION
This changes actually related to [this PR](https://github.com/benahm/TestDataFactory/pull/21). 

If the unique value was set to `test0123456`, but the maximum text field length is 5, it will throw an error `STRING_TOO_LONG`. So this code cut the string to `23456`.

I decided to cut the start of the string, so this way it can still be unique.

Maybe it's a bit extra :)