### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -149,7 +149,7 @@ Create a list of 100 Account sObjects with list of 5 different names that will l
 
 ##### Create 10 Cases related to 10 Accounts
 
-Create a list of Acount sObjects and link them to a list of 10 Case sObjects
+Create a list of Account sObjects and link them to a list of 10 Case sObjects
   ```apex
   List<Account> accList = TestDataFactory.createSObjectList('Account', new Map<String,Object>{
     'Description' => 'Account Description'

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -2,10 +2,10 @@
 ## Limitations 🛑
 
 
-#### Default values for picklist/mulipicklist fields 
+#### Default values for picklist/multipicklist fields
 
 
-For an sObject that has multiple record types, TestDataFactory will assign the default picklist value and if the default value is not assigned to the used recrod type, you will get the error below
+For an sObject that has multiple record types, TestDataFactory will assign the default picklist value and if the default value is not assigned to the used record type, you will get the error below
 
 *Example: Contact has multiple record types and the field CustomField__c has 'TEST' value as default, but it's not assigned to the record types*
 	


### PR DESCRIPTION
## Summary
- correct typos in LIMITATIONS docs
- correct typo in EXAMPLES docs

## Testing
- `sfdx force:apex:test:run --help` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869af89121c832ba1891d14fbc7ebd2