### PR TITLE
Fix Salesforce spelling in documentation

### DIFF
--- a/force-app/main/default/classes/TestDataFactory.cls
+++ b/force-app/main/default/classes/TestDataFactory.cls
@@ -1025,7 +1025,7 @@ public class TestDataFactory {
         }
 
         /**
-        * @description get the Saleforce default value for given picklist
+        * @description get the Salesforce default value for given picklist
         * @param fieldDesc (Schema.DescribeFieldResult): field describe information
         * @return The picklist default value on Salesforce
         */


### PR DESCRIPTION
## Summary
- fix Salesforce spelling in comment above `getSFDefaultPicklistValue`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6869afb66b78832b8be3adb41662e5a6